### PR TITLE
feat: add optional rustls-tls feature for TLS backend choice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1131,7 @@ dependencies = [
  "http 0.2.12",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1127,7 +1142,8 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1135,12 +1151,28 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1170,12 +1202,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4910321ebe4151be888e35fe062169554e74aad01beafed60410131420ceffbc"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1204,6 +1314,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -1354,6 +1474,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,6 +1621,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,8 +1650,12 @@ dependencies = [
  "futures-util",
  "log",
  "native-tls",
+ "rustls 0.22.4",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.25.0",
  "tungstenite",
 ]
 
@@ -1566,6 +1717,8 @@ dependencies = [
  "log",
  "native-tls",
  "rand",
+ "rustls 0.22.4",
+ "rustls-pki-types",
  "sha1",
  "thiserror",
  "url",
@@ -1589,6 +1742,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -1745,6 +1904,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "which"
@@ -2133,6 +2298,12 @@ dependencies = [
  "syn 2.0.114",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,13 @@ crate-type = ["lib", "cdylib"]
 bench = false
 path = "src/lib.rs"
 
+[features]
+default = ["native-tls"]
+native-tls = ["reqwest/native-tls", "tokio-tungstenite/connect", "tokio-tungstenite/native-tls"]
+rustls-tls = ["reqwest/rustls-tls", "tokio-tungstenite/connect", "tokio-tungstenite/rustls-tls-native-roots"]
+
 [dependencies]
-reqwest = { version = "0.11", features = ["json", "multipart"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "multipart"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
@@ -32,7 +37,7 @@ tokio = { version = "1", features = ["full"] }
 prost = "0.12"
 chrono = { version = "0.4.42", features = ["serde"] }
 uuid = { version = "1.18.1", features = ["rng-getrandom", "v4"] }
-tokio-tungstenite = { version = "0.21", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.21", default-features = false }
 futures-util = "0.3"
 urlencoding = "2.1"
 regex = "1.0"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ anylist_rs = "0.1.0"
 tokio = { version = "1", features = ["full"] }
 ```
 
+### TLS Backend
+
+By default, anylist_rs uses the system's native TLS implementation (`native-tls`), which relies on OpenSSL on Linux, Secure Transport on macOS, and SChannel on Windows.
+
+For environments where OpenSSL is unavailable or undesirable (such as musl-based Linux distributions, static builds, or cross-compilation), you can use `rustls` instead:
+
+```toml
+[dependencies]
+anylist_rs = { version = "0.1.0", default-features = false, features = ["rustls-tls"] }
+```
+
+| Feature | TLS Implementation | Use Case |
+|---------|-------------------|----------|
+| `native-tls` (default) | System TLS (OpenSSL/SecureTransport/SChannel) | Standard deployments, system certificate store integration |
+| `rustls-tls` | rustls (pure Rust) | Static builds, musl/Alpine Linux, cross-compilation, no OpenSSL dependency |
+
 ## Examples
 
 - [Lists](./docs/examples/lists.rs)

--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -37,6 +37,24 @@ impl Ingredient {
         }
     }
 
+    /// Set the quantity (builder pattern)
+    pub fn quantity_of(mut self, quantity: impl Into<String>) -> Self {
+        self.quantity = Some(quantity.into());
+        self
+    }
+
+    /// Set the note (builder pattern)
+    pub fn note_of(mut self, note: impl Into<String>) -> Self {
+        self.note = Some(note.into());
+        self
+    }
+
+    /// Set the raw ingredient text (builder pattern)
+    pub fn raw_ingredient_of(mut self, raw: impl Into<String>) -> Self {
+        self.raw_ingredient = Some(raw.into());
+        self
+    }
+
     pub fn name(&self) -> &str {
         &self.name
     }


### PR DESCRIPTION
Thanks for the merge of my PR and no worries at all about your approach. I definitely pondered if it was worth trying to upstream what is only vibe code, but figured it may at least help with something eventually!

I think the only thing that I'm missing from being able to build off this repo instead of my fork is the support for rust-tls. Home Assistant's environment doesn't have Rust build tools, thus the easiest way to get this installed in HA is to provide a pre-built wheel. I spent a bit of time trying to get pipelines to build this as it was configured with only errors in the way, whereas embedding rustls  worked first time for me. I've updated my approach to make this optional (as I definitely agree that using system OpenSSL is the "better" answer).

Equally, if you have suggestions on how to do the cross compilation in a pipeline that doesn't require this, I'm equally happy to accept any suggestions!

---
Add feature flags to choose between native-tls (default) and rustls-tls:
- native-tls: Uses system TLS (OpenSSL/SecureTransport/SChannel)
- rustls-tls: Pure Rust TLS, useful for static builds and cross-compilation

This allows users in environments without OpenSSL (musl/Alpine, static builds) to use rustls instead, while maintaining native-tls as the default for existing users.