### PR TITLE
fix: set image/jpeg MIME type on recipe photo upload

### DIFF
--- a/src/recipes.rs
+++ b/src/recipes.rs
@@ -846,12 +846,13 @@ impl AnyListClient {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn upload_photo(&self, data: Vec<u8>, filename: &str) -> Result<String> {
+    pub async fn upload_photo(&self, data: Vec<u8>, _filename: &str) -> Result<String> {
         let photo_id = generate_id();
         let server_filename = format!("{}.jpg", photo_id);
 
         let photo_part = reqwest::multipart::Part::bytes(data)
-            .file_name(filename.to_string());
+            .file_name(server_filename.clone())
+            .mime_str("image/jpeg")?;
 
         let form = reqwest::multipart::Form::new()
             .text("filename", server_filename)
@@ -860,6 +861,25 @@ impl AnyListClient {
         self.post_multipart_form("/data/photos/upload", form).await?;
 
         Ok(photo_id)
+    }
+
+    /// Download an existing recipe photo by photo ID.
+    pub async fn download_photo(&self, photo_id: &str) -> Result<Vec<u8>> {
+        let url = format!("https://photos.anylist.com/{photo_id}.jpg");
+        let resp = reqwest::get(&url)
+            .await
+            .map_err(|e| crate::AnyListError::NetworkError(e.to_string()))?;
+        if !resp.status().is_success() {
+            return Err(crate::AnyListError::NetworkError(format!(
+                "Photo download failed: HTTP {}",
+                resp.status()
+            )));
+        }
+        let bytes = resp
+            .bytes()
+            .await
+            .map_err(|e| crate::AnyListError::NetworkError(e.to_string()))?;
+        Ok(bytes.to_vec())
     }
 }
 


### PR DESCRIPTION
## Summary
- `upload_photo` was sending the photo part without a MIME type, which the AnyList API rejects/handles inconsistently for recipe photos. This sets `image/jpeg` explicitly and uses the server-generated filename for the multipart part (matching the `filename` field also sent in the form).
- Adds `download_photo`, a small helper to fetch an existing recipe photo by ID from `https://photos.anylist.com/{photo_id}.jpg`, mirroring how the AnyList apps serve recipe photos.

## Test plan
- [x] `cargo build`
- [x] `cargo test`