### PR TITLE
Pass recipe_data_id and add create_recipe_collection_with_recipe_ids

### DIFF
--- a/src/collections.rs
+++ b/src/collections.rs
@@ -30,6 +30,14 @@ impl RecipeCollection {
 }
 
 impl AnyListClient {
+    async fn get_recipe_data_id(&self) -> Result<Option<String>> {
+        Ok(self
+            .get_user_data()
+            .await?
+            .recipe_data_response
+            .and_then(|response| response.recipe_data_id))
+    }
+
     pub async fn get_recipe_collections(&self) -> Result<Vec<RecipeCollection>> {
         let data = self.get_user_data().await?;
         let collections = match data.recipe_data_response {
@@ -55,14 +63,30 @@ impl AnyListClient {
     ///
     /// * `name` - The name of the collection
     pub async fn create_recipe_collection(&self, name: &str) -> Result<RecipeCollection> {
+        self.create_recipe_collection_with_recipe_ids(name, Vec::new())
+            .await
+    }
+
+    /// Create a new recipe collection pre-populated with recipe IDs
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the collection
+    /// * `recipe_ids` - Initial recipe IDs to include in the collection
+    pub async fn create_recipe_collection_with_recipe_ids(
+        &self,
+        name: &str,
+        recipe_ids: Vec<String>,
+    ) -> Result<RecipeCollection> {
         let collection_id = generate_id();
         let operation_id = generate_id();
+        let recipe_data_id = self.get_recipe_data_id().await?;
 
         let new_collection = PbRecipeCollection {
             identifier: collection_id.clone(),
             timestamp: Some(current_timestamp()),
             name: Some(name.to_string()),
-            recipe_ids: vec![],
+            recipe_ids: recipe_ids.clone(),
             collection_settings: Some(PbRecipeCollectionSettings {
                 recipes_sort_order: Some(0), // Manual
                 show_only_recipes_with_no_collection: Some(false),
@@ -72,18 +96,18 @@ impl AnyListClient {
         let operation = PbRecipeOperation {
             metadata: Some(PbOperationMetadata {
                 operation_id: Some(operation_id),
-                handler_id: Some("new-recipe-collection".to_string()),
+                handler_id: Some("save-recipe-collection".to_string()),
                 user_id: Some(self.user_id()),
                 operation_class: Some(OperationClass::Undefined as i32),
             }),
-            recipe_data_id: None,
+            recipe_data_id,
             recipe: None,
             recipe_collection: Some(new_collection),
             recipe_link_request: None,
-            recipe_collection_ids: vec![],
+            recipe_collection_ids: vec![collection_id.clone()],
             recipes: vec![],
             is_new_recipe_from_web_import: Some(false),
-            recipe_ids: vec![],
+            recipe_ids: recipe_ids.clone(),
         };
 
         let operation_list = PbRecipeOperationList {
@@ -100,7 +124,7 @@ impl AnyListClient {
         Ok(RecipeCollection {
             id: collection_id,
             name: name.to_string(),
-            recipe_ids: vec![],
+            recipe_ids,
         })
     }
 
@@ -111,6 +135,7 @@ impl AnyListClient {
     /// * `collection_id` - The ID of the collection to delete
     pub async fn delete_recipe_collection(&self, collection_id: &str) -> Result<()> {
         let operation_id = generate_id();
+        let recipe_data_id = self.get_recipe_data_id().await?;
 
         let operation = PbRecipeOperation {
             metadata: Some(PbOperationMetadata {
@@ -119,7 +144,7 @@ impl AnyListClient {
                 user_id: Some(self.user_id()),
                 operation_class: Some(OperationClass::Undefined as i32),
             }),
-            recipe_data_id: None,
+            recipe_data_id,
             recipe: None,
             recipe_collection: None,
             recipe_link_request: None,
@@ -154,6 +179,7 @@ impl AnyListClient {
         recipe_id: &str,
     ) -> Result<()> {
         let operation_id = generate_id();
+        let recipe_data_id = self.get_recipe_data_id().await?;
 
         // Get the current collection
         let collections = self.get_recipe_collections().await?;
@@ -187,7 +213,7 @@ impl AnyListClient {
                 user_id: Some(self.user_id()),
                 operation_class: Some(OperationClass::Undefined as i32),
             }),
-            recipe_data_id: None,
+            recipe_data_id,
             recipe: None,
             recipe_collection: Some(updated_collection),
             recipe_link_request: None,
@@ -222,6 +248,7 @@ impl AnyListClient {
         recipe_id: &str,
     ) -> Result<()> {
         let operation_id = generate_id();
+        let recipe_data_id = self.get_recipe_data_id().await?;
 
         // Get the current collection
         let collections = self.get_recipe_collections().await?;
@@ -257,7 +284,7 @@ impl AnyListClient {
                 user_id: Some(self.user_id()),
                 operation_class: Some(OperationClass::Undefined as i32),
             }),
-            recipe_data_id: None,
+            recipe_data_id,
             recipe: None,
             recipe_collection: Some(updated_collection),
             recipe_link_request: None,


### PR DESCRIPTION
## Summary
- All collection write operations (`create`, `delete`, `add_recipe_to`, `remove_recipe_from`) now look up `recipe_data_id` from the user-data response and include it in the `PBRecipeOperation`, matching what the official client sends.
- Adds `create_recipe_collection_with_recipe_ids` so callers can create a collection pre-populated with recipe IDs in a single network round-trip.
- Fixes the handler ID for new collections: was `"new-recipe-collection"`, should be `"save-recipe-collection"`.
- Populates `recipe_collection_ids` on create (was `vec![]`).

## Test plan
- [x] `cargo test -p anylist_rs` passes