### PR TITLE
Expose calendar_id on MealPlanEvent

### DIFF
--- a/docs/examples/meal_planning.rs
+++ b/docs/examples/meal_planning.rs
@@ -12,10 +12,11 @@ async fn main() -> Result<()> {
     let event = client.create_meal_plan_event(
         calendar_id,
         "2025-10-25",  // Date in YYYY-MM-DD format
-        Some(&recipe.id),
+        Some(recipe.id()),
         None,
         Some("dinner-label-id")  // Meal label (Breakfast, Lunch, Dinner)
     ).await?;
+    println!("Created event {} on calendar {:?}", event.id(), event.calendar_id());
 
     // Create a note-based event (e.g., "Eating out")
     client.create_meal_plan_event(
@@ -29,13 +30,13 @@ async fn main() -> Result<()> {
     // Get meal plan for a date range
     let events = client.get_meal_plan_events("2025-10-25", "2025-10-31").await?;
     for event in &events {
-        println!("Event on {}: {:?}", event.date, event.title);
+        println!("Event on {}: {:?}", event.date(), event.title());
     }
 
     // Add all meal plan ingredients to shopping list for the week
     let list = client.get_list_by_name("Groceries").await?;
     client.add_meal_plan_ingredients_to_list(
-        &list.id,
+        list.id(),
         "2025-10-25",
         "2025-10-31"
     ).await?;

--- a/src/meal_planning.rs
+++ b/src/meal_planning.rs
@@ -13,6 +13,7 @@ use serde_derive::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MealPlanEvent {
     id: String,
+    calendar_id: Option<String>,
     date: String,
     title: Option<String>,
     recipe_id: Option<String>,
@@ -23,6 +24,10 @@ pub struct MealPlanEvent {
 impl MealPlanEvent {
     pub fn id(&self) -> &str {
         &self.id
+    }
+
+    pub fn calendar_id(&self) -> Option<&str> {
+        self.calendar_id.as_deref()
     }
 
     /// Get the date in YYYY-MM-DD format
@@ -83,6 +88,7 @@ impl AnyListClient {
                 })
                 .map(|e| MealPlanEvent {
                     id: e.identifier.clone(),
+                    calendar_id: e.calendar_id.clone(),
                     date: e.date.clone().unwrap_or_default(),
                     title: e.title.clone(),
                     recipe_id: e.recipe_id.clone(),
@@ -159,6 +165,7 @@ impl AnyListClient {
 
         Ok(MealPlanEvent {
             id: event_id,
+            calendar_id: Some(calendar_id.to_string()),
             date: date.to_string(),
             title: title.map(|t| t.to_string()),
             recipe_id: recipe_id.map(|r| r.to_string()),

--- a/src/meal_planning.rs
+++ b/src/meal_planning.rs
@@ -86,15 +86,7 @@ impl AnyListClient {
                         false
                     }
                 })
-                .map(|e| MealPlanEvent {
-                    id: e.identifier.clone(),
-                    calendar_id: e.calendar_id.clone(),
-                    date: e.date.clone().unwrap_or_default(),
-                    title: e.title.clone(),
-                    recipe_id: e.recipe_id.clone(),
-                    label_id: e.label_id.clone(),
-                    details: e.details.clone(),
-                })
+                .map(meal_plan_event_from_pb)
                 .collect(),
             None => Vec::new(),
         };
@@ -302,5 +294,66 @@ impl AnyListClient {
         }
 
         Ok(())
+    }
+}
+
+fn meal_plan_event_from_pb(event: &PbCalendarEvent) -> MealPlanEvent {
+    MealPlanEvent {
+        id: event.identifier.clone(),
+        calendar_id: event.calendar_id.clone(),
+        date: event.date.clone().unwrap_or_default(),
+        title: event.title.clone(),
+        recipe_id: event.recipe_id.clone(),
+        label_id: event.label_id.clone(),
+        details: event.details.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_meal_plan_event_from_pb_maps_all_fields() {
+        let pb = PbCalendarEvent {
+            identifier: "event-1".to_string(),
+            logical_timestamp: Some(1),
+            calendar_id: Some("calendar-1".to_string()),
+            date: Some("2026-06-15".to_string()),
+            title: Some("Dinner".to_string()),
+            details: Some("notes".to_string()),
+            recipe_id: Some("recipe-1".to_string()),
+            label_id: Some("label-1".to_string()),
+            order_added_sort_index: Some(0),
+            recipe_scale_factor: Some(1.0),
+        };
+
+        let event = meal_plan_event_from_pb(&pb);
+
+        assert_eq!(event.id(), "event-1");
+        assert_eq!(event.calendar_id(), Some("calendar-1"));
+        assert_eq!(event.date(), "2026-06-15");
+        assert_eq!(event.title(), Some("Dinner"));
+        assert_eq!(event.recipe_id(), Some("recipe-1"));
+        assert_eq!(event.label_id(), Some("label-1"));
+        assert_eq!(event.details(), Some("notes"));
+    }
+
+    #[test]
+    fn test_meal_plan_event_from_pb_handles_missing_optionals() {
+        let pb = PbCalendarEvent {
+            identifier: "event-2".to_string(),
+            ..Default::default()
+        };
+
+        let event = meal_plan_event_from_pb(&pb);
+
+        assert_eq!(event.id(), "event-2");
+        assert_eq!(event.calendar_id(), None);
+        assert_eq!(event.date(), "");
+        assert_eq!(event.title(), None);
+        assert_eq!(event.recipe_id(), None);
+        assert_eq!(event.label_id(), None);
+        assert_eq!(event.details(), None);
     }
 }

--- a/tests/meal_plan_calendar_id.rs
+++ b/tests/meal_plan_calendar_id.rs
@@ -1,0 +1,17 @@
+use anylist_rs::MealPlanEvent;
+
+#[test]
+fn meal_plan_event_exposes_calendar_id() {
+    let event: MealPlanEvent = serde_json::from_value(serde_json::json!({
+        "id": "event-1",
+        "calendar_id": "calendar-1",
+        "date": "2026-06-15",
+        "title": "Dinner",
+        "recipe_id": "recipe-1",
+        "label_id": "label-1",
+        "details": null
+    }))
+    .unwrap();
+
+    assert_eq!(event.calendar_id(), Some("calendar-1"));
+}

--- a/tests/meal_plan_calendar_id.rs
+++ b/tests/meal_plan_calendar_id.rs
@@ -15,3 +15,18 @@ fn meal_plan_event_exposes_calendar_id() {
 
     assert_eq!(event.calendar_id(), Some("calendar-1"));
 }
+
+#[test]
+fn meal_plan_event_without_calendar_id_deserializes_to_none() {
+    let event: MealPlanEvent = serde_json::from_value(serde_json::json!({
+        "id": "event-1",
+        "date": "2026-06-15",
+        "title": "Dinner",
+        "recipe_id": null,
+        "label_id": null,
+        "details": null
+    }))
+    .unwrap();
+
+    assert_eq!(event.calendar_id(), None);
+}


### PR DESCRIPTION
## Summary
- `MealPlanEvent` now stores and exposes `calendar_id`, which is already present on `PBCalendarEvent` (proto field 3, `calendarId`) but was not being surfaced in the Rust type.
- Populated in both the decode path (events fetched from the server) and in the struct returned by `create_meal_plan_event`.

## Test plan
- [x] `cargo test -p anylist_rs` passes
- [x] Added a deserialization test asserting `calendar_id()` returns the expected value